### PR TITLE
Feature/kazuki/improve front routing

### DIFF
--- a/front_end/Routing.tsx
+++ b/front_end/Routing.tsx
@@ -38,7 +38,7 @@ class Routing extends React.Component<Props, State> {
                 <Route path='*' component={Hello} />
               </Route>
 
-              <Route path="*" render={() => <h1>No content</h1>} />
+              <Route path="*" render={() => <h1>No contents</h1>} />
             </Switch>
           </Auth>
 

--- a/front_end/components/Top.tsx
+++ b/front_end/components/Top.tsx
@@ -58,7 +58,7 @@ const useStyles = makeStyles((theme) => ({
   },
 }));
 
-export default function Header() {
+export default function Top() {
   const classes = useStyles();
 
   return (

--- a/front_end/components/auth/Auth.tsx
+++ b/front_end/components/auth/Auth.tsx
@@ -1,5 +1,6 @@
 import * as React from 'react'
 import { connect } from 'react-redux'
+import { Route, Switch, Redirect } from 'react-router'
 import { bindActionCreators } from 'redux'
 import 'react-toastify/dist/ReactToastify.css'
 import 'react-toastify/dist/ReactToastify.min.css'
@@ -80,11 +81,16 @@ class Auth extends React.Component<Props, State> {
     return (
       <React.Fragment>
         {
-          this.state.loggedInStatus === 'LOGGED_IN' ?
-            Object.keys(this.props.user).length
-              ? this.props.children
-              : <LoadingIcon />
-          : <Top />
+          this.state.loggedInStatus === 'LOGGED_IN'
+            ?
+              Object.keys(this.props.user).length
+                ? this.props.children
+                : <LoadingIcon />
+            :
+              <Switch>
+                <Route exact path='/' component={Top} />
+                <Redirect from='*' to='/' />
+              </Switch>
         }
       </React.Fragment>
     )


### PR DESCRIPTION
## Changes
非ログイン時にはルートパスでトップページへリダイレクトさせる。

## Related links
https://app.asana.com/0/1139931625502159/1198180132762129

## Test result

* [x] E2Eテストが通る。
* [x] 非ログイン時には `/`,  `/signin`, `/signup` のみアクセスできる
* [ ] 

## Others
