### PR TITLE
Feature/kazuki/optimize bulk query

### DIFF
--- a/app/controllers/api/v1/expenditure_logs_controller.rb
+++ b/app/controllers/api/v1/expenditure_logs_controller.rb
@@ -35,12 +35,15 @@ module Api
         begin
           existing_log_ids = @current_user.expenditure_logs.ids
 
+          # パラメータの中身が全て
+          # existing_log_idsに一致しないならば処理中止
           return response_bad_request unless expenditure_log_ids.all? { |id| existing_log_ids.include?(id) }
 
           query = "DELETE FROM `expenditure_logs` WHERE `expenditure_logs`.`id` IN (#{expenditure_log_ids})"
           query.delete!('[]')
           ActiveRecord::Base.connection.execute(query)
 
+          # ログに関連するtag relationを一括削除
           query = "DELETE FROM `tag_relations` WHERE `tag_relations`.`expenditure_log_id` IN (#{expenditure_log_ids})"
           query.delete!('[]')
           ActiveRecord::Base.connection.execute(query)

--- a/app/controllers/api/v1/expenditure_logs_controller.rb
+++ b/app/controllers/api/v1/expenditure_logs_controller.rb
@@ -32,18 +32,20 @@ module Api
       end
 
       def bulk_delete
-        # OPTIMIZE: 可能ならSQL delete処理にしたい。
         begin
-          ActiveRecord::Base.transaction do
-            expenditure_logs = @current_user.expenditure_logs
+          existing_log_ids = @current_user.expenditure_logs.ids
 
-            expenditure_log_ids.each do |id|
-              expenditure_logs.find(id)
-                              .try(:destroy!)
-            end
+          return response_bad_request unless expenditure_log_ids.all? { |id| existing_log_ids.include?(id) }
 
-            response_success(:expenditure_logs, :delete)
-          end
+          query = "DELETE FROM `expenditure_logs` WHERE `expenditure_logs`.`id` IN (#{expenditure_log_ids})"
+          query.delete!('[]')
+          ActiveRecord::Base.connection.execute(query)
+
+          query = "DELETE FROM `tag_relations` WHERE `tag_relations`.`expenditure_log_id` IN (#{expenditure_log_ids})"
+          query.delete!('[]')
+          ActiveRecord::Base.connection.execute(query)
+
+          response_success(:expenditure_logs, :delete)
         rescue => exception
           response_internal_server_error
         end

--- a/app/controllers/api/v1/tags_controller.rb
+++ b/app/controllers/api/v1/tags_controller.rb
@@ -58,7 +58,6 @@ module Api
         end
       end
 
-      # TODO: フロントRedux Storeへ反映
       def relate_to_income_log
         log = @current_user.income_logs.find(log_id)
         using_tag_relations = log.tag_relations

--- a/app/models/tag.rb
+++ b/app/models/tag.rb
@@ -2,7 +2,7 @@ class Tag < ApplicationRecord
   # create update時
   # before_save { self.color = '#' + color } // TODO: 正規表現 ?
 
-  has_many :tag_relations, dependent: :destroy
+  has_many :tag_relations, dependent: :delete_all
   has_many :expenditure_logs, through: :tag_relations
   has_many :income_logs, through: :tag_relations
   belongs_to :user

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -5,3 +5,60 @@
 #
 #   movies = Movie.create([{ name: 'Star Wars' }, { name: 'Lord of the Rings' }])
 #   Character.create(name: 'Luke', movie: movies.first)
+
+ts = Time.zone.now
+p = 'aaaaaa'
+
+ActiveRecord::Base.transaction do
+  u = User.create!(name: "#{ts}さん", email: "a@a.a", password: p, password_confirmation: p)
+
+  # 3.times do |i|
+  #   MonthlyExpenditure.create!()
+  # end
+
+  10.times do
+    ramdom_color = "#" + SecureRandom.hex(3)
+
+    Tag.create!(
+      user_id: u.id,
+      name: "タグネーム",
+      color: ramdom_color,
+      description: '説明'
+    )
+  end
+
+  100.times do |i|
+    i += 1
+
+    tag_id = (i % 10 == 0) ? 10 : i % 10 
+
+    e = ExpenditureLog.new(
+      user_id: u.id,
+      title: 'タイトル',
+      amount: i,
+      content: '内容'
+    )
+
+    e.save!
+
+    tr = TagRelation.new(
+      expenditure_log_id: e.id,
+      tag_id: tag_id
+    )
+    tr.save!
+
+    i = IncomeLog.new(
+      user_id: u.id,
+      title: 'タイトル',
+      amount: i,
+      content: '内容'
+    )
+    i.save!
+
+    tr = TagRelation.new(
+      income_log_id: i.id,
+      tag_id: tag_id
+    )
+    tr.save!
+  end
+end

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -10,7 +10,7 @@ ts = Time.zone.now
 p = 'aaaaaa'
 
 ActiveRecord::Base.transaction do
-  u = User.create!(name: "#{ts}さん", email: "a@a.a", password: p, password_confirmation: p)
+  u = User.create!(name: "Aさん", email: "a@a.a", password: p, password_confirmation: p)
 
   # 3.times do |i|
   #   MonthlyExpenditure.create!()

--- a/front_end/components/logs/expenditure/ExpenditureLogsTable.tsx
+++ b/front_end/components/logs/expenditure/ExpenditureLogsTable.tsx
@@ -21,11 +21,12 @@ import Checkbox from '@material-ui/core/Checkbox';
 import FormControlLabel from '@material-ui/core/FormControlLabel';
 import Switch from '@material-ui/core/Switch';
 import DeleteAlert from '../common/DeleteAlert';
-import { successMessage, succesmMessages } from '../../GlobalMessage';
 import TagAttachedToExpenditure from './TagAttachedToExpenditure';
 import { TextField, Grid } from '@material-ui/core';
 import PaidAtPickers from './common/PaidAtpickers';
 import ExpenditurePieChart from './common/ExpenditurePieChart';
+import { setLoadingMessage } from '../../../modules/CommonModule';
+import Notification, { progress, error, success } from '../../../models/Notification';
 
 interface tableData {
   title: string;
@@ -199,14 +200,20 @@ const ExpenditureLogsTable: React.FC = () => {
   const emptyRows = rowsPerPage - Math.min(rowsPerPage, rows.length - page * rowsPerPage)
 
   const handleDeleteClick = (expenditureLog: ExpenditureLog) => {
+    dispatch(setLoadingMessage(progress.destroy))
+
     deleteExpenditureLog(expenditureLog)
       .then((expenditureLog: ExpenditureLog) => {
         dispatch(editExpenditureLog('DESTROY_EXPENDITURE_LOG', expenditureLog))
         removeCheck(expenditureLog)
-        successMessage(succesmMessages.destroy)
+
+        Notification.successMessage(success.destroy)
+        dispatch(setLoadingMessage(null))
       })
       .catch(response => {
         console.error(response)
+        Notification.errorMessage(error.destroy)
+        dispatch(setLoadingMessage(null))
       })
   }
 

--- a/front_end/components/logs/expenditure/common/ExpenditurePieChart.tsx
+++ b/front_end/components/logs/expenditure/common/ExpenditurePieChart.tsx
@@ -5,13 +5,6 @@ import Tag, { pendingChartData } from '../../../../models/Tag';
 import ExpenditureLog from '../../../../models/ExpenditureLog';
 import { Grid, makeStyles, createStyles } from '@material-ui/core';
 
-const calculateTotalAmount = (chartData: pendingChartData[]): number => {
-  const totalAmount = chartData.map(d => d.totalAmount)
-  return totalAmount.reduce(additionReducer, 0)
-}
-
-const additionReducer = (accumulator: number, currentValue: number): number => accumulator + currentValue
-
 const { useState } = React
 
 const useStyles = makeStyles(() => createStyles({
@@ -62,11 +55,11 @@ const ExpenditurePieChart: React.FC<Props> = (props) => {
   React.useEffect(() => {
     Tag.createChartData(tags, props.logs)
       .then(pendingChartData => {
-        setTotalAmount(calculateTotalAmount(pendingChartData))
+        setTotalAmount(Tag.calculateTotalAmount(pendingChartData))
         setTagColor(Tag.extractTagColorObj(pendingChartData))
         setData(Tag.confirmChartData(pendingChartData))
       })
-  }, [tags, expenditureLogs ,props.logs])
+  }, [tags, expenditureLogs, props.logs])
 
   return (
     <React.Fragment>
@@ -80,7 +73,7 @@ const ExpenditurePieChart: React.FC<Props> = (props) => {
             : null}
           </Grid>
 
-          {props.logs && props.logs.length ?
+          {expenditureLogs && props.logs.length ?
             <Grid item>
               <Chart
                 graph_id={props.graphID}
@@ -110,7 +103,7 @@ const ExpenditurePieChart: React.FC<Props> = (props) => {
           : null}
 
           <Grid item>
-            total:<strong className={classes.chartAmount}>{totalAmount}¥</strong>
+            total:<strong className={classes.chartAmount}>{expenditureLogs.length ? totalAmount : 0}¥</strong>
             <br />
             <p>lorem ipsum lorem ipsum</p>
             <strong>lorem ipsum lorem ipsum</strong>

--- a/front_end/components/logs/income/IncomeLogsTable.tsx
+++ b/front_end/components/logs/income/IncomeLogsTable.tsx
@@ -20,13 +20,13 @@ import Paper from '@material-ui/core/Paper';
 import Checkbox from '@material-ui/core/Checkbox';
 import FormControlLabel from '@material-ui/core/FormControlLabel';
 import Switch from '@material-ui/core/Switch';
-import CreateIncomeLogModal from './CreateIncomeLogModal';
 import DeleteAlert from '../common/DeleteAlert';
-import { successMessage, succesmMessages } from '../../GlobalMessage';
 import TagAttachedToIncome from './TagAttachedToIncome';
 import { TextField, Grid } from '@material-ui/core';
 import EarnedAtPickers from './common/EarnedAtPicker';
 import IncomePieChart from './common/IncomePieChart';
+import { setLoadingMessage } from '../../../modules/CommonModule';
+import Notification, { progress, success, error } from '../../../models/Notification';
 
 interface tableData {
   title: string;
@@ -200,14 +200,20 @@ const IncomeLogsTable: React.FC = () => {
   const emptyRows = rowsPerPage - Math.min(rowsPerPage, rows.length - page * rowsPerPage)
 
   const handleDeleteClick = (incomeLog: IncomeLog) => {
+    dispatch(setLoadingMessage(progress.destroy))
+
     deleteIncomeLog(incomeLog)
       .then((incomeLog: IncomeLog) => {
         dispatch(editIncomeLog('DESTROY_INCOME_LOG', incomeLog))
         removeCheck(incomeLog)
-        successMessage(succesmMessages.destroy)
+
+        Notification.successMessage(success.destroy)
+        dispatch(setLoadingMessage(null))
       })
       .catch(response => {
         console.error(response)
+        Notification.errorMessage(error.destroy)
+        dispatch(setLoadingMessage(null))
       })
   }
 

--- a/front_end/components/logs/income/common/IncomePieChart.tsx
+++ b/front_end/components/logs/income/common/IncomePieChart.tsx
@@ -5,13 +5,6 @@ import Tag, { pendingChartData } from '../../../../models/Tag';
 import IncomeLog from '../../../../models/IncomeLog';
 import { Grid, makeStyles, createStyles } from '@material-ui/core';
 
-const calculateTotalAmount = (chartData: pendingChartData[]): number => {
-  const totalAmount = chartData.map(d => d.totalAmount)
-  return totalAmount.reduce(additionReducer, 0)
-}
-
-const additionReducer = (accumulator: number, currentValue: number): number => accumulator + currentValue
-
 const { useState } = React
 
 const useStyles = makeStyles(() => createStyles({
@@ -60,9 +53,9 @@ const IncomePieChart: React.FC<Props> = (props) => {
   const [totalAmount, setTotalAmount] = useState<number>(0)
 
   React.useEffect(() => {
-    Tag.createChartData(tags, props.logs || incomeLogs)
+    Tag.createChartData(tags, props.logs)
       .then(pendingChartData => {
-        setTotalAmount(calculateTotalAmount(pendingChartData))
+        setTotalAmount(Tag.calculateTotalAmount(pendingChartData))
         setTagColor(Tag.extractTagColorObj(pendingChartData))
         setData(Tag.confirmChartData(pendingChartData))
       })
@@ -80,7 +73,7 @@ const IncomePieChart: React.FC<Props> = (props) => {
             : null}
           </Grid>
 
-          {props.logs && props.logs.length ?
+          {incomeLogs && props.logs.length ?
             <Grid item>
               <Chart
                 graph_id={props.graphID}
@@ -110,7 +103,7 @@ const IncomePieChart: React.FC<Props> = (props) => {
           : null}
 
           <Grid item>
-            total:<strong className={classes.chartAmount}>{totalAmount}¥</strong>
+            total:<strong className={classes.chartAmount}>{incomeLogs.length ? totalAmount : 0}¥</strong>
             <br />
             <p>lorem ipsum lorem ipsum</p>
             <strong>lorem ipsum lorem ipsum</strong>

--- a/front_end/models/Tag.ts
+++ b/front_end/models/Tag.ts
@@ -90,4 +90,13 @@ export default class Tag {
   static extractTagColorObj(data: pendingChartData[]): Array<{color: string}> {
     return data.map(d => ({ color: d.color }))
   }
+
+  static calculateTotalAmount(chartData: pendingChartData[]): number {
+    const totalAmount = chartData.map(d => d.totalAmount)
+    return totalAmount.reduce(this.additionReducer, 0)
+  }
+
+  private static additionReducer(accumulator: number, currentValue: number): number {
+    return accumulator + currentValue
+  }
 }


### PR DESCRIPTION
## Changes
一括削除処理のクエリを改善

```
Unpermitted parameter: :income_log
Unpermitted parameter: :income_log
   (37.6ms)  DELETE FROM `income_logs` WHERE `income_logs`.`id` IN (90, 91, 94, 95, 96)
  ↳ app/controllers/api/v1/income_logs_controller.rb:44:in `bulk_delete'
Unpermitted parameter: :income_log
   (4.6ms)  DELETE FROM `tag_relations` WHERE `tag_relations`.`income_log_id` IN (90, 91, 94, 95, 96)
  ↳ app/controllers/api/v1/income_logs_controller.rb:49:in `bulk_delete'
Completed 200 OK in 55ms (Views: 0.3ms | ActiveRecord: 43.0ms | Allocations: 3117)
```

## Related links

## Test result

* [x] featureテストOK
* [x] log一括削除時、タグ削除時クエリ速度改善(sql delete処理)
* [x] sqlインジェクションされない？根拠は？
>クエリ実行前にパラメータ(数字の配列) が `全て` リクエストを実行したユーザーが保持するログのidと一致するかどうかを確認しているため。

例) expenditure logを一括削除
```ruby
existing_log_ids = @current_user.expenditure_logs.ids
# 1 ユーザーに紐づくexpenditure logのidを全て取得
return response_bad_request unless expenditure_log_ids.all? { |id| existing_log_ids.include?(id) }
# 2 expenditure_log_ids(整数の配列)の中身が全て1の配列に含まれていないならクエリ実行中止
```

## Others
テーブルのレンダリングが遅い